### PR TITLE
Tiny documentation update for Couchbase component

### DIFF
--- a/components/camel-couchbase/src/main/docs/couchbase-component.adoc
+++ b/components/camel-couchbase/src/main/docs/couchbase-component.adoc
@@ -14,7 +14,7 @@
 *{component-header}*
 
 The *couchbase:* component allows you to treat
-https://www.couchbase.com/[CouchBase] instances as a producer or consumer
+https://www.couchbase.com/[Couchbase] instances as a producer or consumer
 of messages.
 
 Maven users will need to add the following dependency to their `pom.xml`
@@ -56,7 +56,7 @@ include::partial$component-endpoint-headers.adoc[]
 
 == Couchbase SDK compatibility
 
-Using collections and scopes is supported only for Couchbase Enterprise Server 6.5+.
+Using collections and scopes is supported only for Couchbase Server 7.0+.
 
 This component is currently using Java SDK 3.x so it might be not compatible with older Couchbase servers anymore. See the compatibility https://docs.couchbase.com/java-sdk/current/project-docs/compatibility.html[page].
 


### PR DESCRIPTION
# Description

Fix minor documentation issues found during a review of the Couchbase component source code:

The product name is styled as "Couchbase" (not "CouchBase").
Reference:  https://www.couchbase.com

Couchbase Server 7.0 is the earliest version with full support for scopes and collections. (This feature was present in 6.5 only in "Developer Preview" mode, which is not intended for production use; if I recall correctly, modern versions of the Java SDK are not compatible with some aspects of the early developer preview implementation).
References:
* https://docs.couchbase.com/server/7.0/introduction/whats-new.html#whats-new-server-700
* https://docs.couchbase.com/server/6.5/developer-preview/preview-mode.html

Scopes and collections are supported in Couchbase Server Community Edition (CE) as well as Enterprise Edition (CE). 
Reference: https://www.couchbase.com/products/editions/

# Target

This PR targets the main branch. The same changes also apply to 3.x, but I haven't made a PR for that.

# Tracking

This is a minor documentation fix, so i did not file a Jira issue.

# Apache Camel coding standards and style

- [X] I checked that each commit in the pull request has a meaningful subject line and body.
